### PR TITLE
Search py4j jar in upper level

### DIFF
--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -210,7 +210,10 @@ def find_jar_path():
     #   the jar file is here: virtualenvpath/share/py4j/py4j.jar
     paths.append(os.path.join(os.path.dirname(
             os.path.realpath(__file__)), "../../../../share/py4j/" + jar_file))
-
+    
+    paths.append(os.path.join(os.path.dirname(
+            os.path.realpath(__file__)), "../../../share/py4j/" + jar_file))
+    
     for path in paths:
         if os.path.exists(path):
             return path


### PR DESCRIPTION
On fresh Python 3.9 windows install in user path, the share dir is located one level upper. So just add this in search paths.